### PR TITLE
Reset killed gauge reward rate

### DIFF
--- a/contracts/LpSugar.vy
+++ b/contracts/LpSugar.vy
@@ -455,13 +455,16 @@ def _byData(_data: address[3], _account: address) -> Lp:
   pool_fees: address = pool.poolFees()
   token0: IERC20 = IERC20(pool.token0())
   token1: IERC20 = IERC20(pool.token1())
+  gauge_alive: bool = self.voter.isAlive(gauge.address)
 
   if gauge.address != empty(address):
     acc_staked = gauge.balanceOf(_account)
     earned = gauge.earned(_account)
     gauge_total_supply = gauge.totalSupply()
-    emissions = gauge.rewardRate()
     emissions_token = gauge.rewardToken()
+
+  if gauge_alive:
+    emissions = gauge.rewardRate()
 
   if _data[0] != self.v1_factory:
     pool_fee = IPoolFactory(_data[0]).getFee(_data[1], is_stable)
@@ -483,7 +486,7 @@ def _byData(_data: address[3], _account: address) -> Lp:
 
     gauge: gauge.address,
     gauge_total_supply: gauge_total_supply,
-    gauge_alive: self.voter.isAlive(gauge.address),
+    gauge_alive: gauge_alive,
 
     fee: self.voter.gaugeToFees(gauge.address),
     bribe: self.voter.gaugeToBribe(gauge.address),

--- a/readme.md
+++ b/readme.md
@@ -73,8 +73,6 @@ The available methods are:
    returns a paginated list of `Lp` structs.
  * `byIndex(_index: uint256, _account: address) -> Lp` - returns the
    `Lp` data for a specific index of a pool.
- * `byAddress(_address: address, _account: address) -> Lp` - returns the
-   `Lp` data for a specific pool address.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ Below is the list of datasets we support.
 
 ### Liquidity Pools Data
 
-`LpSugar.vy` is deployed at `0xD2B1D1B75a0f226722b3A174dAE54e6dD14af1a1`
+`LpSugar.vy` is deployed at `0x7F45F1eA57E9231f846B2b4f5F8138F94295A726`
 
 It allows fetching on-chain pools data.
 The returned data/struct of type `Lp` values represent:


### PR DESCRIPTION
Gauge reward rate does not update after it is killed, so we need to ignore the values.