### PR TITLE
feat: use RelayFactory, add latest epoch compounded rewards

### DIFF
--- a/contracts/RelaySugar.vy
+++ b/contracts/RelaySugar.vy
@@ -22,7 +22,7 @@ struct Relay:
   voted_at: uint256
   votes: DynArray[LpVotes, MAX_PAIRS]
   token: address
-  rewards_compounded: uint256
+  compounded: uint256
   manager: address
   relay: address
   inactive: bool
@@ -170,7 +170,7 @@ def _byAddress(_relay: address, _account: address) -> Relay:
     voted_at: last_voted,
     votes: votes,
     token: relay.token(),
-    rewards_compounded: rewards_compounded,
+    compounded: rewards_compounded,
     manager: manager,
     relay: _relay,
     inactive: inactive,


### PR DESCRIPTION
Supports both AutoConverters and AutoCompounders by fetching them from the RelayFactory that has been added in Airton's PR

Fetch the Relay struct's `token` from the contract, so that we know which token is being compounded into regardless of whether it is an AutoConverter or AutoCompounder

Add the recently compounded rewards to the Relay struct output, `rewards_compounded`

