### PR TITLE
fix: Relay's last voted timestamp on VeSugar

### DIFF
--- a/contracts/VeSugar.vy
+++ b/contracts/VeSugar.vy
@@ -158,13 +158,10 @@ def _byId(_id: uint256) -> VeNFT:
   governance_amount: uint256 = self.gov.getVotes(_id, block.timestamp)
 
   delegate_id: uint256 = self.ve.delegates(_id)
+  managed_id: uint256 = self.ve.idToManaged(_id)
 
-  if self.ve.voted(_id):
+  if managed_id != 0 or self.ve.voted(_id):
     last_voted = self.voter.lastVoted(_id)
-  else:
-    managed_id: uint256 = self.ve.idToManaged(_id)
-    if managed_id != 0:
-      last_voted = self.voter.lastVoted(managed_id)
 
   vote_weight: uint256 = self.voter.usedWeights(_id)
   # Since we don't have a way to see how many pools we voted...

--- a/readme.md
+++ b/readme.md
@@ -132,7 +132,7 @@ To fetch a list of rewards for a specific veNFT, this method is available:
 
 ### Vote-Escrow Locked NFT (veNFT) Data
 
-`VeSugar.vy` is deployed at `0xAED3DE5586acd2Aba23F5FB8811e9A7ffaF80773`
+`VeSugar.vy` is deployed at `0x37403dBd6f1b583ea244F7956fF9e37EF45c63eB`
 
 It allows fetching on-chain veNFT data (including the rewards accrued).
 The returned data/struct of type `VeNFT` values represent:


### PR DESCRIPTION
Will be paired with changing https://github.com/velodrome-finance/app/blob/v2/src/pages/Locks/components/RelayLock.tsx#L8 to `const canWithdraw = venft.epochStartedAt.gt(venft.voted_at);` so the UI matches up with the solidity