### PR TITLE
Check current epoch period before reporting emissions.

### DIFF
--- a/contracts/LpSugar.vy
+++ b/contracts/LpSugar.vy
@@ -210,6 +210,7 @@ interface IGauge:
   def rewardRate() -> uint256: view
   def rewardRateByEpoch(_ts: uint256) -> uint256: view
   def rewardToken() -> address: view
+  def lastTimeRewardApplicable() -> uint256: view
 
 interface ICLGauge:
   def earned(_account: address, _position_id: uint256) -> uint256: view
@@ -219,6 +220,7 @@ interface ICLGauge:
   def feesVotingReward() -> address: view
   def stakedContains(_account: address, _position_id: uint256) -> bool: view
   def stakedValues(_account: address) -> DynArray[uint256, MAX_POSITIONS]: view
+  def lastTimeRewardApplicable() -> uint256: view
 
 interface INFPositionManager:
   def positions(_position_id: uint256) -> PositionData: view
@@ -546,7 +548,7 @@ def _v2_lp(_data: address[4], _token0: address, _token1: address) -> Lp:
     gauge_liquidity = gauge.totalSupply()
     emissions_token = gauge.rewardToken()
 
-  if gauge_alive:
+  if gauge_alive and gauge.lastTimeRewardApplicable() > block.timestamp:
     emissions = gauge.rewardRate()
     if gauge_liquidity > 0:
       token0_fees = (pool.claimable0(_data[2]) * pool_liquidity) / gauge_liquidity
@@ -881,7 +883,7 @@ def _cl_lp(_data: address[4], _token0: address, _token1: address) -> Lp:
     token0_fees = staked_fees.amount0
     token1_fees = staked_fees.amount1
 
-    if gauge_alive:
+    if gauge_alive and gauge.lastTimeRewardApplicable() > block.timestamp:
       emissions = gauge.rewardRate()
 
   return Lp({


### PR DESCRIPTION
Fixed the case where a gauge would still report emissions after not getting votes (and not being updated).